### PR TITLE
Add setup.py, .gitignore and ability to use test endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,62 @@
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Created by .ignore support plugin (hsz.mobi)
+.idea/

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from distutils.core import setup
+
+setup(
+    name='vitadock-oauth',
+    version='0.1',
+    packages=['vitadock'],
+    url='https://github.com/gkotsis/vitadock-oauth',
+    license='Version 2.0',
+    author='George Gkotsis',
+    author_email='gkotsis@gmail.com',
+    description=''
+)

--- a/vitadock/api.py
+++ b/vitadock/api.py
@@ -11,14 +11,17 @@ import urllib
 from vitadock.utils import generate_timestamp, generate_nonce
 
 
+API_ENDPOINT = "https://cloud.vitadock.com"
+API_ENDPOINT_TEST = "https://test-cloud.vitadock.com"
+
+
 class VitadockOauthClient(object):
-	API_ENDPOINT = "https://cloud.vitadock.com"
+	def __init__(self, app_key, app_secret, request_token=None,request_token_secret=None, test=False):
+		endpoint = API_ENDPOINT_TEST if test else API_ENDPOINT
+		self.request_token_url = "%s/auth/unauthorizedaccesses" % endpoint
+		self.access_token_url = "%s/auth/accesses/verify" % endpoint
+		self.authorization_url = "%s/desiredaccessrights/request" % endpoint
 
-	request_token_url = "%s/auth/unauthorizedaccesses" % API_ENDPOINT
-	access_token_url = "%s/auth/accesses/verify" % API_ENDPOINT
-	authorization_url = "%s/desiredaccessrights/request" % API_ENDPOINT
-
-	def __init__(self, app_key, app_secret, request_token=None,request_token_secret=None):
 		self.app_key = app_key
 		self.app_secret = app_secret
 		self.request_token = request_token


### PR DESCRIPTION
Added standard .gitignore for Python to ignore compiled files and IDE files

Added setup.py to allow this library be installed via pip install and requirements.txt:
`pip install https://github.com/mick88/vitadock-oauth.git#egg=vitadock-oauth`

Added ability to use test vitadock endpoint instead of just the main one by setting `test` parameter to True in the constructor (default False for backwards compatibility)
